### PR TITLE
avoid errors if no messages, finish move messages todo

### DIFF
--- a/src/imap_extract/mod.rs
+++ b/src/imap_extract/mod.rs
@@ -70,7 +70,7 @@ impl ImapExtract {
             let mut count = 0;
             for message in messages.iter() {
                 count += 1;
-                if count % log_each_msg == 0 {
+                if count > 0 || count % log_each_msg == 0 {
                     writeln!(
                         logbuf,
                         "{:.0} % done",


### PR DESCRIPTION
depending on message count you can get a couple errors:

- `thread 'rocket-worker-thread' panicked at 'attempt to calculate the remainder with a divisor of zero', src/imap_extract/mod.rs:71:16`

- if no messages browser will show an error with "undefined" in a red error box.  This is a couple issues, one is because the IMAP server does not like if you fetch an empty mailbox, so checked if message count was > 0.  The other issue is the return json field says "error", but js code is looking for "err" so you get "undefined" instead of the error message.  I fixed the first issue, but not the second (I am not sure if you prefer to use err or error)

also finished the move messages functionality